### PR TITLE
Added ability to override `currentNibName` in table cell subclasses.

### DIFF
--- a/Quickly/Table/QTableCell+iOS.swift
+++ b/Quickly/Table/QTableCell+iOS.swift
@@ -8,6 +8,10 @@
         Type: IQTableRow
     >: UITableViewCell, IQView, IQTypedTableCell {
 
+        open class func currentNibName() -> String {
+            return String(describing: self.classForCoder())
+        }
+        
         public override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
             super.init(style: style, reuseIdentifier: reuseIdentifier)
             self.setup()


### PR DESCRIPTION
Долго объяснять, так что на великом и могучем. Есть протокол `IQTableReuse`, у него статический метод `currentNibName() -> String`. Дефолтная реализация этого метода лежит рядом в extension протокола. Очень странно, но в проекте я не могу его "переопределить". Возможно проблема опять в дженериках, что врядли, т.к. если в проект запихать `extension IQTableReuse where Self: UITableView { ... }`, то ни одна реализация внутри него не вызывается. Если этот же код положить в `Quickly`, то все ок. В итоге единственный рабочий вариант оказался в этом коммите.